### PR TITLE
Hotfix 2 for version 2.1

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -99,7 +99,7 @@
             ".validate": "newData.isString() && newData.val() == auth.uid"
           },
           "message": {
-            ".validate": "newData.isString() && newData.val().length > 0"
+            ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 250"
           },
           "time": {
             ".validate": "newData.isNumber() && newData.val() == now"
@@ -120,7 +120,7 @@
           ".validate": "newData.isString() && newData.val() == auth.uid"
         },
         "message": {
-          ".validate": "newData.isString() && newData.val().length > 0"
+          ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 250"
         },
         "time": {
           ".validate": "newData.isNumber() && newData.val() == now"

--- a/database.rules.json
+++ b/database.rules.json
@@ -50,9 +50,9 @@
       }
     },
     "users": {
-      ".read": "auth != null",
       ".indexOn": "connections",
       "$userId": {
+        ".read": "auth != null",
         ".write": "auth != null && auth.uid == $userId",
         ".validate": "newData.hasChildren(['color', 'name'])",
         "color": {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -111,7 +111,7 @@ function generateDeck() {
 
 /** Periodically remove stale user connections */
 export const clearConnections = functions.pubsub
-  .schedule("every 2 minutes")
+  .schedule("every 1 minutes")
   .onRun(async (context) => {
     const onlineUsers = await admin
       .database()
@@ -120,11 +120,14 @@ export const clearConnections = functions.pubsub
       .startAt(false)
       .once("value");
     const actions: Array<Promise<void>> = [];
+    let numUsers = 0;
     onlineUsers.forEach((snap) => {
+      ++numUsers;
       if (Math.random() < 0.1) {
         console.log(`Clearing connections for ${snap.ref.toString()}`);
         actions.push(snap.ref.child("connections").remove());
       }
     });
+    actions.push(admin.database().ref("stats/onlineUsers").set(numUsers));
     await Promise.all(actions);
   });

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -87,6 +87,7 @@ function Chat() {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Type a message..."
+          maxLength={250}
         />
       </form>
     </section>

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 
 import User from "./User";
+import InternalLink from "./InternalLink";
 import SimpleInput from "./SimpleInput";
 import firebase from "../firebase";
 import autoscroll from "../utils/autoscroll";
@@ -77,7 +78,13 @@ function Chat() {
             title={<ElapsedTime value={msg.time} />}
           >
             <Typography variant="body2" gutterBottom>
-              <User id={msg.user} />: {msg.message}
+              <User
+                id={msg.user}
+                component={InternalLink}
+                to={`/profile/${msg.user}`}
+                underline="none"
+              />
+              : {msg.message}
             </Typography>
           </Tooltip>
         ))}

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -45,7 +45,7 @@ function Chat() {
 
   const messagesQuery = useMemo(
     () =>
-      firebase.database().ref("lobbyChat").orderByChild("time").limitToLast(50),
+      firebase.database().ref("lobbyChat").orderByChild("time").limitToLast(30),
     []
   );
   const messages = useFirebaseQuery(messagesQuery);

--- a/src/components/GameChat.js
+++ b/src/components/GameChat.js
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 
 import User from "./User";
+import InternalLink from "./InternalLink";
 import SimpleInput from "./SimpleInput";
 import SetCard from "./SetCard";
 import firebase from "../firebase";
@@ -125,7 +126,13 @@ function GameChat({ gameId, history, startedAt }) {
               </Tooltip>
             ) : (
               <Typography key={key} variant="body2" gutterBottom>
-                <User id={item.user} />: {item.message}
+                <User
+                  id={item.user}
+                  component={InternalLink}
+                  to={`/profile/${item.user}`}
+                  underline="none"
+                />
+                : {item.message}
               </Typography>
             )
           )}

--- a/src/components/GameChat.js
+++ b/src/components/GameChat.js
@@ -135,6 +135,7 @@ function GameChat({ gameId, history, startedAt }) {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Type a message..."
+          maxLength={250}
         />
       </form>
     </section>

--- a/src/components/InternalLink.js
+++ b/src/components/InternalLink.js
@@ -1,0 +1,10 @@
+import React, { forwardRef } from "react";
+
+import Link from "@material-ui/core/Link";
+import { Link as RouterLink } from "react-router-dom";
+
+function InternalLink(props) {
+  return <Link component={RouterLink} {...props} />;
+}
+
+export default forwardRef(InternalLink);

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,12 +1,10 @@
 import React, { useState, useContext } from "react";
 
-import { Link as RouterLink } from "react-router-dom";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
-import Link from "@material-ui/core/Link";
 import EditIcon from "@material-ui/icons/Edit";
 import Brightness3Icon from "@material-ui/icons/Brightness3";
 import WbSunnyIcon from "@material-ui/icons/WbSunny";
@@ -14,6 +12,7 @@ import WbSunnyIcon from "@material-ui/icons/WbSunny";
 import firebase from "../firebase";
 import { UserContext } from "../context";
 import User from "./User";
+import InternalLink from "./InternalLink";
 import PromptDialog from "./PromptDialog";
 
 function Navbar({ themeType, handleChangeTheme }) {
@@ -31,19 +30,15 @@ function Navbar({ themeType, handleChangeTheme }) {
     <AppBar position="relative" color="transparent" elevation={0}>
       <Toolbar variant="dense">
         <Typography variant="h6" style={{ flexGrow: 1, whiteSpace: "nowrap" }}>
-          <Link underline="none" color="inherit" component={RouterLink} to="/">
+          <InternalLink underline="none" color="inherit" to="/">
             Set with Friends
-          </Link>
+          </InternalLink>
         </Typography>
         <Typography
           variant="subtitle1"
           style={{ marginLeft: "2em", marginRight: 8, minWidth: 0 }}
         >
-          <Link
-            underline="none"
-            component={RouterLink}
-            to={`/profile/${user.id}`}
-          >
+          <InternalLink underline="none" to={`/profile/${user.id}`}>
             <User
               id={user.id}
               style={{
@@ -53,7 +48,7 @@ function Navbar({ themeType, handleChangeTheme }) {
                 whiteSpace: "nowrap",
               }}
             />
-          </Link>
+          </InternalLink>
         </Typography>
         <IconButton color="inherit" onClick={() => setChangeName(true)}>
           <Tooltip title="Change name">

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -4,7 +4,8 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import Container from "@material-ui/core/Container";
 import Paper from "@material-ui/core/Paper";
-import { Link as RouterLink } from "react-router-dom";
+
+import InternalLink from "../components/InternalLink";
 
 function AboutPage() {
   return (
@@ -28,9 +29,7 @@ function AboutPage() {
         </Typography>
       </Paper>
       <Typography variant="body1" align="center" gutterBottom>
-        <Link component={RouterLink} to="/">
-          Return to home
-        </Link>
+        <InternalLink to="/">Return to home</InternalLink>
       </Typography>
     </Container>
   );

--- a/src/pages/ContactPage.js
+++ b/src/pages/ContactPage.js
@@ -4,7 +4,8 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import Container from "@material-ui/core/Container";
 import Paper from "@material-ui/core/Paper";
-import { Link as RouterLink } from "react-router-dom";
+
+import InternalLink from "../components/InternalLink";
 
 function ContactPage() {
   return (
@@ -23,9 +24,7 @@ function ContactPage() {
         </Typography>
       </Paper>
       <Typography variant="body1" align="center">
-        <Link component={RouterLink} to="/" gutterBottom>
-          Return to home
-        </Link>
+        <InternalLink to="/">Return to home</InternalLink>
       </Typography>
     </Container>
   );

--- a/src/pages/HelpPage.js
+++ b/src/pages/HelpPage.js
@@ -4,8 +4,8 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import Container from "@material-ui/core/Container";
 import Paper from "@material-ui/core/Paper";
-import { Link as RouterLink } from "react-router-dom";
 
+import InternalLink from "../components/InternalLink";
 import SetCard from "../components/SetCard";
 
 function HelpPage() {
@@ -134,9 +134,7 @@ function HelpPage() {
         </Typography>
       </Paper>
       <Typography variant="body1" align="center" gutterBottom>
-        <Link component={RouterLink} to="/">
-          Return to home
-        </Link>
+        <InternalLink to="/">Return to home</InternalLink>
       </Typography>
     </Container>
   );

--- a/src/pages/LobbyPage.js
+++ b/src/pages/LobbyPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useContext } from "react";
 
 import generate from "project-name-generator";
-import { Link as RouterLink, Redirect } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Container from "@material-ui/core/Container";
@@ -23,6 +23,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import firebase, { createGame } from "../firebase";
 import useFirebaseQuery from "../hooks/useFirebaseQuery";
 import useFirebaseRef from "../hooks/useFirebaseRef";
+import InternalLink from "../components/InternalLink";
 import GameInfoRow from "../components/GameInfoRow";
 import Chat from "../components/Chat";
 import { UserContext } from "../context";
@@ -256,18 +257,9 @@ function LobbyPage() {
         </Box>
       </Grid>
       <Typography variant="body1" align="center" style={{ padding: "16px 0" }}>
-        <Link component={RouterLink} to="/help">
-          Help
-        </Link>{" "}
-        •{" "}
-        <Link component={RouterLink} to="/about">
-          About
-        </Link>{" "}
-        •{" "}
-        <Link component={RouterLink} to="/contact">
-          Contact
-        </Link>{" "}
-        •{" "}
+        <InternalLink to="/help">Help</InternalLink> •{" "}
+        <InternalLink to="/about">About</InternalLink> •{" "}
+        <InternalLink to="/contact">Contact</InternalLink> •{" "}
         <Link target="_blank" rel="noopener" href="https://discord.gg/XbjJyc9">
           Discord
         </Link>

--- a/src/pages/LobbyPage.js
+++ b/src/pages/LobbyPage.js
@@ -12,10 +12,6 @@ import Box from "@material-ui/core/Box";
 import Link from "@material-ui/core/Link";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
-import ListItemIcon from "@material-ui/core/ListItemIcon";
-import ListItemText from "@material-ui/core/ListItemText";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -23,16 +19,12 @@ import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Tooltip from "@material-ui/core/Tooltip";
-import Divider from "@material-ui/core/Divider";
-import FaceIcon from "@material-ui/icons/Face";
-import SportsEsportsIcon from "@material-ui/icons/SportsEsports";
 
 import firebase, { createGame } from "../firebase";
 import useFirebaseQuery from "../hooks/useFirebaseQuery";
 import useFirebaseRef from "../hooks/useFirebaseRef";
 import GameInfoRow from "../components/GameInfoRow";
 import Chat from "../components/Chat";
-import User from "../components/User";
 import { UserContext } from "../context";
 
 const useStyles = makeStyles((theme) => ({
@@ -124,15 +116,6 @@ function LobbyPage() {
   const [waiting, setWaiting] = useState(false);
   const [tabValue, setTabValue] = useState(0);
 
-  const onlineUsersQuery = useMemo(() => {
-    return firebase
-      .database()
-      .ref("users")
-      .orderByChild("connections")
-      .startAt(false);
-  }, []);
-  const onlineUsers = useFirebaseQuery(onlineUsersQuery);
-
   const gamesQuery = useMemo(() => {
     return firebase
       .database()
@@ -172,78 +155,12 @@ function LobbyPage() {
     }
   }
 
-  function isIngame(user) {
-    for (const url of Object.values(user.connections || {})) {
-      if (url.startsWith("/game")) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   return (
     <Container>
       <Grid container spacing={2} className={classes.mainGrid}>
         <Box clone order={{ xs: 3, md: 1 }} className={classes.chatColumn}>
           <Grid item xs={12} sm={12} md={3}>
             <Paper className={classes.chatColumnPaper}>
-              <section
-                className={classes.chatPanel}
-                style={{
-                  flexShrink: 0,
-                  maxHeight: "40%",
-                }}
-              >
-                <Typography variant="overline">
-                  Online Users ({Object.keys(onlineUsers).length})
-                </Typography>
-                <List
-                  dense
-                  disablePadding
-                  style={{ overflowY: "auto", flexGrow: 1 }}
-                >
-                  {Object.keys(onlineUsers).map((userId) => (
-                    <User
-                      key={userId}
-                      id={userId}
-                      component={Typography}
-                      variant="body2"
-                      noWrap
-                      render={(thisUser, userEl) => (
-                        <ListItem
-                          button
-                          component={RouterLink}
-                          to={`/profile/${userId}`}
-                        >
-                          <ListItemIcon>
-                            {isIngame(thisUser) ? (
-                              <Tooltip title="In a game">
-                                <SportsEsportsIcon />
-                              </Tooltip>
-                            ) : (
-                              <Tooltip title="Online user">
-                                <FaceIcon />
-                              </Tooltip>
-                            )}
-                          </ListItemIcon>
-
-                          <ListItemText disableTypography>
-                            {userEl}
-                          </ListItemText>
-                          {userId === user.id && (
-                            <ListItemText
-                              style={{ flex: "0 0 auto", marginLeft: 8 }}
-                            >
-                              (You)
-                            </ListItemText>
-                          )}
-                        </ListItem>
-                      )}
-                    />
-                  ))}
-                </List>
-              </section>
-              <Divider style={{ margin: "8px 0" }} />
               <Chat user={user} />
             </Paper>
           </Grid>
@@ -322,6 +239,12 @@ function LobbyPage() {
               </Tooltip>
             </div>
             <div className={classes.gameCounters}>
+              <Typography variant="body2" gutterBottom>
+                <strong>
+                  {loadingStats ? "---" : stats ? stats.onlineUsers : 0}
+                </strong>{" "}
+                users online
+              </Typography>
               <Typography variant="body2" gutterBottom>
                 <strong>
                   {loadingStats ? "-----" : stats ? stats.gameCount : 0}

--- a/src/pages/LobbyPage.js
+++ b/src/pages/LobbyPage.js
@@ -138,7 +138,7 @@ function LobbyPage() {
       .database()
       .ref("/publicGames")
       .orderByValue()
-      .limitToLast(50);
+      .limitToLast(35);
   }, []);
   const games = useFirebaseQuery(gamesQuery);
 
@@ -147,7 +147,7 @@ function LobbyPage() {
       .database()
       .ref(`/userGames/${user.id}`)
       .orderByValue()
-      .limitToLast(50);
+      .limitToLast(35);
   }, [user.id]);
   const myGames = useFirebaseQuery(myGamesQuery);
 

--- a/src/pages/NotFoundPage.js
+++ b/src/pages/NotFoundPage.js
@@ -1,8 +1,7 @@
 import React from "react";
 import Typography from "@material-ui/core/Typography";
-import Link from "@material-ui/core/Link";
 import Container from "@material-ui/core/Container";
-import { Link as RouterLink } from "react-router-dom";
+import InternalLink from "../components/InternalLink";
 import cowImage from "../assets/cow_404.png";
 
 function NotFoundPage() {
@@ -17,9 +16,9 @@ function NotFoundPage() {
         style={{ display: "block", maxWidth: "100%", margin: "0 auto 8px" }}
       />
       <Typography variant="body1" align="center">
-        <Link component={RouterLink} to="/" gutterBottom>
+        <InternalLink to="/" gutterBottom>
           Return to home
-        </Link>
+        </InternalLink>
       </Typography>
     </Container>
   );


### PR DESCRIPTION
Second hotfix for v2.1, also fixing scaling issues, but this time focusing on billing. Most important change was nixing the lobby "online users" list, which takes a lot of expensive database bandwidth to synchronize in the current model. Our cost scaling should now be actually O(n).

### Changes

- Limit number of characters allowed per message in chat to 250
- Decrease the number of recent games and messages shown in the lobby (50 → 35)
- Remove the detailed online users list from lobby, only show statistics updated per minute
- Add links to user profiles in chat messages