### PR TITLE
Filter stats for game types

### DIFF
--- a/src/components/ProfileName.js
+++ b/src/components/ProfileName.js
@@ -58,14 +58,10 @@ function ProfileName({ userId }) {
         return (
           <section>
             <div
-              style={{ display: "flex", flexDirection: "row" }}
+              style={{ display: "flex", flexDirection: "row", marginBottom: 6 }}
               className={classes.name}
             >
-              <Typography
-                variant="h4"
-                gutterBottom
-                style={{ overflowWrap: "anywhere" }}
-              >
+              <Typography variant="h4" style={{ overflowWrap: "anywhere" }}>
                 {userEl}
               </Typography>
               {user.admin && (

--- a/src/components/UserStatistics.js
+++ b/src/components/UserStatistics.js
@@ -12,7 +12,6 @@ const useStyles = makeStyles((theme) => ({
   statisticsPanel: {
     background: theme.palette.background.panel,
     padding: theme.spacing(2),
-    borderRadius: 6,
   },
   stats: {
     display: "flex",

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -41,12 +41,12 @@ function mergeGameData(game, gameData) {
   };
 }
 
-const GAME_SUBSETS = [
+const DATA_SET_VARIANT = [
   { key: "all", label: "All Games" },
   { key: "solo", label: "Solo Games" },
   { key: "multiplayer", label: "Multiplayer Games" },
 ];
-const GAME_SUBSET_FILTER_FUNCTIONS = {
+const DATA_SET_VARIANT_FILTER_FUNCTIONS = {
   all: (gameData) => true,
   solo: (gameData) => Object.keys(gameData.scores).length === 1,
   multiplayer: (gameData) => Object.keys(gameData.scores).length > 1,
@@ -58,7 +58,7 @@ function ProfilePage({ match }) {
 
   const [games, loadingGames] = useFirebaseRef(`/userGames/${userId}`, true);
   const [redirect, setRedirect] = useState(null);
-  const [gameSet, setGameSet] = useState("all");
+  const [dataSetVariant, setDataSetVariant] = useState("all");
 
   const handleClickGame = (gameId) => {
     setRedirect(`/room/${gameId}`);
@@ -91,14 +91,14 @@ function ProfilePage({ match }) {
       if (gameVals[i].status === "done") {
         const gameData = mergeGameData(gameVals[i], gameDataVals[i]);
         gamesData[gameIds[i]] = gameData;
-        if (GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gameData)) {
+        if (DATA_SET_VARIANT_FILTER_FUNCTIONS[dataSetVariant](gameData)) {
           gameStatsData[gameIds[i]] = gameData;
         }
       }
     }
   }
-  const handleGameSetChange = (event) => {
-    setGameSet(event.target.value);
+  const handleDataSetVariantChange = (event) => {
+    setDataSetVariant(event.target.value);
   };
 
   return (
@@ -122,11 +122,11 @@ function ProfilePage({ match }) {
             <TextField
               select
               label="Game Set"
-              value={gameSet}
-              onChange={handleGameSetChange}
+              value={dataSetVariant}
+              onChange={handleDataSetVariantChange}
               helperText="Subset of games to show stats"
             >
-              {GAME_SUBSETS.map(({ key, label }) => (
+              {DATA_SET_VARIANT.map(({ key, label }) => (
                 <MenuItem key={key} value={key}>
                   {label}
                 </MenuItem>

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -7,7 +7,7 @@ import Grid from "@material-ui/core/Grid";
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
-import TextField from "@material-ui/core/TextField";
+import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import EqualizerIcon from "@material-ui/icons/Equalizer";
 
@@ -113,23 +113,25 @@ function ProfilePage({ match }) {
             className={classes.divider}
           />
           <Grid item xs={12} style={{ flex: 1 }} p={1}>
-            <div style={{ display: "flex" }}>
-              <Typography variant="overline">Statistics</Typography>
-              <EqualizerIcon />
+            <div style={{ display: "flex", alignItems: "flex-end" }}>
+              <div style={{ display: "flex" }}>
+                <Typography variant="overline">Statistics</Typography>
+                <EqualizerIcon />
+              </div>
+
+              <Select
+                value={variant}
+                onChange={(event) => setVariant(event.target.value)}
+                style={{ marginLeft: "auto" }}
+                color="secondary"
+              >
+                {Object.entries(datasetVariants).map(([key, { label }]) => (
+                  <MenuItem key={key} value={key}>
+                    <Typography variant="body2">{label}</Typography>
+                  </MenuItem>
+                ))}
+              </Select>
             </div>
-            <TextField
-              select
-              label="Game Set"
-              value={variant}
-              onChange={(event) => setVariant(event.target.value)}
-              helperText="Subset of games to show stats"
-            >
-              {Object.entries(datasetVariants).map(([key, { label }]) => (
-                <MenuItem key={key} value={key}>
-                  {label}
-                </MenuItem>
-              ))}
-            </TextField>
             <UserStatistics userId={userId} gamesData={gamesData} />
           </Grid>
         </Grid>

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -86,18 +86,16 @@ function ProfilePage({ match }) {
   let gameStatsData = null;
   if (!loadingGameVals && !loadingGameDataVals) {
     gamesData = {};
+    gameStatsData = {};
     for (let i = 0; i < gameIds.length; i++) {
       if (gameVals[i].status === "done") {
-        gamesData[gameIds[i]] = mergeGameData(gameVals[i], gameDataVals[i]);
+        const gameData = mergeGameData(gameVals[i], gameDataVals[i]);
+        gamesData[gameIds[i]] = gameData;
+        if (GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gameData)) {
+          gameStatsData[gameIds[i]] = gameData;
+        }
       }
     }
-    gameStatsData = Object.keys(gamesData)
-      .filter((gameId) =>
-        GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gamesData[gameId])
-      )
-      .reduce((outputData, gameId) => {
-        outputData[gameId] = gamesData[gameId];
-      }, {});
   }
   const handleGameSetChange = (event) => {
     setGameSet(event.target.value);

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -42,9 +42,9 @@ function mergeGameData(game, gameData) {
 }
 
 const GAME_SUBSETS = [
-  { key: 'all', label: 'All Games' },
-  { key: 'solo', label: 'Solo Games' },
-  { key: 'multiplayer', label: 'Multiplayer Games' },
+  { key: "all", label: "All Games" },
+  { key: "solo", label: "Solo Games" },
+  { key: "multiplayer", label: "Multiplayer Games" },
 ];
 const GAME_SUBSET_FILTER_FUNCTIONS = {
   all: (gameData) => true,
@@ -58,7 +58,7 @@ function ProfilePage({ match }) {
 
   const [games, loadingGames] = useFirebaseRef(`/userGames/${userId}`, true);
   const [redirect, setRedirect] = useState(null);
-  const [gameSet, setGameSet] = useState('all');
+  const [gameSet, setGameSet] = useState("all");
 
   const handleClickGame = (gameId) => {
     setRedirect(`/room/${gameId}`);
@@ -91,15 +91,13 @@ function ProfilePage({ match }) {
       }
     }
   }
-  let gameStatsData = Object.
-    keys(gamesData).
-    filter(gameId => GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gamesData[gameId])).
-    reduce(
-      (outputData, gameId) => {
-        outputData[gameId] = gamesData[gameId];
-      },
-      {}
-    );
+  let gameStatsData = Object.keys(gamesData)
+    .filter((gameId) =>
+      GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gamesData[gameId])
+    )
+    .reduce((outputData, gameId) => {
+      outputData[gameId] = gamesData[gameId];
+    }, {});
   const handleGameSetChange = (event) => {
     setGameSet(event.target.value);
   };
@@ -129,11 +127,11 @@ function ProfilePage({ match }) {
               onChange={handleGameSetChange}
               helperText="Subset of games to show stats"
             >
-              {
-                GAME_SUBSETS.map(({ key, label }) => (
-                  <MenuItem key={key} value={key}>{label}</MenuItem>
-                ))
-              }
+              {GAME_SUBSETS.map(({ key, label }) => (
+                <MenuItem key={key} value={key}>
+                  {label}
+                </MenuItem>
+              ))}
             </TextField>
             <UserStatistics userId={userId} gamesData={gameStatsData} />
           </Grid>

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -83,16 +83,13 @@ function ProfilePage({ match }) {
   }
 
   let gamesData = null;
-  let gameStatsData = null;
   if (!loadingGameVals && !loadingGameDataVals) {
     gamesData = {};
-    gameStatsData = {};
     for (let i = 0; i < gameIds.length; i++) {
       if (gameVals[i].status === "done") {
         const gameData = mergeGameData(gameVals[i], gameDataVals[i]);
-        gamesData[gameIds[i]] = gameData;
         if (DATA_SET_VARIANT_FILTER_FUNCTIONS[dataSetVariant](gameData)) {
-          gameStatsData[gameIds[i]] = gameData;
+          gamesData[gameIds[i]] = gameData;
         }
       }
     }
@@ -132,7 +129,7 @@ function ProfilePage({ match }) {
                 </MenuItem>
               ))}
             </TextField>
-            <UserStatistics userId={userId} gamesData={gameStatsData} />
+            <UserStatistics userId={userId} gamesData={gamesData} />
           </Grid>
         </Grid>
         <Typography variant="overline" component="div">

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -83,6 +83,7 @@ function ProfilePage({ match }) {
   }
 
   let gamesData = null;
+  let gameStatsData = null;
   if (!loadingGameVals && !loadingGameDataVals) {
     gamesData = {};
     for (let i = 0; i < gameIds.length; i++) {
@@ -90,14 +91,14 @@ function ProfilePage({ match }) {
         gamesData[gameIds[i]] = mergeGameData(gameVals[i], gameDataVals[i]);
       }
     }
+    gameStatsData = Object.keys(gamesData)
+      .filter((gameId) =>
+        GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gamesData[gameId])
+      )
+      .reduce((outputData, gameId) => {
+        outputData[gameId] = gamesData[gameId];
+      }, {});
   }
-  let gameStatsData = Object.keys(gamesData)
-    .filter((gameId) =>
-      GAME_SUBSET_FILTER_FUNCTIONS[gameSet](gamesData[gameId])
-    )
-    .reduce((outputData, gameId) => {
-      outputData[gameId] = gamesData[gameId];
-    }, {});
   const handleGameSetChange = (event) => {
     setGameSet(event.target.value);
   };


### PR DESCRIPTION
### Context

I play many many solo games to practice, and only occasionally play
games with other people. When looking at my stats, I'd like to see how I
do playing with others separately from my performance alone.

Very open to suggestions about implementation choices! I went with what
made sense to me, but I can't help but wonder if there's a clearer way
to write the `keys().filter().reduce()` chain.

Originally suggested in Discord: [Link](https://discordapp.com/channels/718326911583125544/718457117756883045/737094564959092756)

### Open Questions

- The term "game set" is unclear even to me. What's the clearest term to use?
- UI Design: I went with the easiest default layout, but I don't like
how it looks. I tried in-lining the select with the "Statistics" title,
but it looked totally wonky with default CSS.

### Screenshots

**Implemented Layout**
![image](https://user-images.githubusercontent.com/1302280/88493389-abd91a80-cf65-11ea-87fe-ad0d54afcc9b.png)

**Inline Layout**
![image](https://user-images.githubusercontent.com/1302280/88493400-bb586380-cf65-11ea-8e4c-7976f7b73e89.png)
