### PR TITLE
Improving color picking functionality

### DIFF
--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -75,11 +75,6 @@ function ColorChoiceDialog(props) {
               color={green}
               onChangeComplete={(result) => setGreen(result.hex)}
             />
-            <br />
-            <br />
-            <Button onClick={handleReset} variant="contained" color="primary">
-              Set Colors to Default
-            </Button>
           </Grid>
           <Grid item xs={12} md={4} className={classes.colorPickerColumn}>
             <ResponsiveSetCard
@@ -92,6 +87,16 @@ function ColorChoiceDialog(props) {
               onChangeComplete={(result) => setRed(result.hex)}
             />
           </Grid>
+        </Grid>
+        <Grid container direction="row" justify="center">
+          <Button
+            onClick={handleReset}
+            variant="contained"
+            color="primary"
+            style={{ marginTop: "15px" }}
+          >
+            Set Colors to Default
+          </Button>
         </Grid>
       </DialogContent>
       <DialogActions>

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -91,8 +91,8 @@ function ColorChoiceDialog(props) {
         <Grid container direction="row" justify="center">
           <Button
             onClick={handleReset}
-            variant="contained"
-            color="primary"
+            variant="outlined"
+            color="secondary"
             style={{ marginTop: "15px" }}
           >
             Set Colors to Default

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -10,8 +10,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import { ChromePicker } from "react-color";
 import ResponsiveSetCard from "./ResponsiveSetCard";
-import { darkTheme } from "../themes";
-import { lightTheme } from "../themes";
+import { darkTheme, lightTheme } from "../themes";
 
 const useStyles = makeStyles({
   colorPickerColumn: {

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -10,6 +10,8 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import { ChromePicker } from "react-color";
 import ResponsiveSetCard from "./ResponsiveSetCard";
+import { darkTheme } from "../themes";
+import { lightTheme } from "../themes";
 
 const useStyles = makeStyles({
   colorPickerColumn: {
@@ -39,14 +41,14 @@ function ColorChoiceDialog(props) {
 
   function handleReset() {
     if (theme.palette.type === "light") {
-      setRed("#ff0101");
-      setGreen("#008002");
-      setPurple("#800080");
+      setRed(lightTheme.setCard.red);
+      setGreen(lightTheme.setCard.green);
+      setPurple(lightTheme.setCard.purple);
     }
     if (theme.palette.type === "dark") {
-      setRed("#ffb047");
-      setGreen("#00b803");
-      setPurple("#ff47ff");
+      setRed(darkTheme.setCard.red);
+      setGreen(darkTheme.setCard.green);
+      setPurple(darkTheme.setCard.purple);
     }
   }
 

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -34,9 +34,7 @@ function ColorChoiceDialog(props) {
   }
 
   function handleSubmit() {
-    if (red === green || green === purple || red === purple) {
-      alert("All colors must be unique");
-    } else onClose({ red: red, green: green, purple: purple });
+    onClose({ red: red, green: green, purple: purple });
   }
 
   function handleReset() {

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -21,7 +21,6 @@ const useStyles = makeStyles({
 
 function ColorChoiceDialog(props) {
   const { open, onClose, title, theme } = props;
-  console.log(theme);
   const classes = useStyles();
 
   const [red, setRed] = useState(theme.setCard.red);
@@ -40,14 +39,14 @@ function ColorChoiceDialog(props) {
 
   function handleReset() {
     if (theme.palette.type === "light") {
-      setGreen("#008002");
       setRed("#ff0101");
+      setGreen("#008002");
       setPurple("#800080");
     }
     if (theme.palette.type === "dark") {
+      setRed("#ffb047");
       setGreen("#00b803");
       setPurple("#ff47ff");
-      setRed("#ffb047");
     }
   }
 

--- a/src/components/ColorChoiceDialog.js
+++ b/src/components/ColorChoiceDialog.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles({
 
 function ColorChoiceDialog(props) {
   const { open, onClose, title, theme } = props;
+  console.log(theme);
   const classes = useStyles();
 
   const [red, setRed] = useState(theme.setCard.red);
@@ -32,7 +33,22 @@ function ColorChoiceDialog(props) {
   }
 
   function handleSubmit() {
-    onClose({ red: red, green: green, purple: purple });
+    if (red === green || green === purple || red === purple) {
+      alert("All colors must be unique");
+    } else onClose({ red: red, green: green, purple: purple });
+  }
+
+  function handleReset() {
+    if (theme.palette.type === "light") {
+      setGreen("#008002");
+      setRed("#ff0101");
+      setPurple("#800080");
+    }
+    if (theme.palette.type === "dark") {
+      setGreen("#00b803");
+      setPurple("#ff47ff");
+      setRed("#ffb047");
+    }
   }
 
   return (
@@ -61,6 +77,11 @@ function ColorChoiceDialog(props) {
               color={green}
               onChangeComplete={(result) => setGreen(result.hex)}
             />
+            <br />
+            <br />
+            <Button onClick={handleReset} variant="contained" color="primary">
+              Set Colors to Default
+            </Button>
           </Grid>
           <Grid item xs={12} md={4} className={classes.colorPickerColumn}>
             <ResponsiveSetCard


### PR DESCRIPTION
This should close #33. Gives the option to set colors to the default (works in light and dark mode), as well as ensuring that user does not select the same color multiple times. I'm not sure if the styling of the default button is okay/my use of an alert is okay for selecting multiple colors, so let me know if I should fix it!

Before clicking set default:
<img width="1463" alt="Screen Shot 2020-08-11 at 4 43 47 PM" src="https://user-images.githubusercontent.com/43389857/89947112-f6a79300-dbf1-11ea-8629-bbc96f8f547a.png">

After:
<img width="1463" alt="Screen Shot 2020-08-11 at 4 43 50 PM" src="https://user-images.githubusercontent.com/43389857/89947123-fe673780-dbf1-11ea-95b1-1e1669297614.png">

If you click okay with multiple colors the same (clicking ok in the alert just keeps the color picker window open, doesn't set the colors or close the window):
<img width="1463" alt="Screen Shot 2020-08-11 at 4 44 10 PM" src="https://user-images.githubusercontent.com/43389857/89947193-10e17100-dbf2-11ea-8886-ce9740f7cafa.png">

