### PR TITLE
Displaying fractions of a second, except when game is active.

### DIFF
--- a/src/components/GameSidebar.js
+++ b/src/components/GameSidebar.js
@@ -55,7 +55,9 @@ function GameSidebar({ game, scores, leaderboard }) {
       <div className={classes.timer} style={{ marginTop: 6 }}>
         <AlarmIcon className={classes.alarm} fontSize="large" />
         <Typography variant="h4" align="center">
-          {formatTime(gameTime - game.startedAt)}
+          {/* Hide the sub-second time resolution while game is active to
+          avoid stressing beginners. */}
+          {formatTime(gameTime - game.startedAt, game.status !== "done")}
         </Typography>
       </div>
       <Divider style={{ margin: "8px 0" }} />

--- a/src/util.js
+++ b/src/util.js
@@ -136,9 +136,10 @@ export function computeState(gameData) {
   return { current, scores, history };
 }
 
-export function formatTime(t) {
+export function formatTime(t, hideSubsecond) {
   t = Math.max(t, 0);
   const hours = Math.floor(t / (3600 * 1000));
   const rest = t % (3600 * 1000);
-  return (hours ? `${hours}:` : "") + moment(rest).format("mm:ss");
+  const format = hideSubsecond ? "mm:ss" : "mm:ss.SS";
+  return (hours ? `${hours}:` : "") + moment(rest).format(format);
 }


### PR DESCRIPTION
This causes all the statistics to show time in hundredths of a second, which is useful to the people who are fighting over top times in the ~1 minute range.

![image](https://user-images.githubusercontent.com/575644/91665146-63eb6d00-eaa8-11ea-89c0-4f5d94ef1d08.png)

I avoided showing hundredths in the sidebar while games are in progress because it makes me feel rushed so it might be a bad experience for beginners. Also, it spares us from doing `const time = useMoment(10)` to achieve rapid re-rendering.

I chose to display hundredths of a second instead of thousandths because that seems more common on physical stopwatches.