### PR TITLE
Fixes #71 - removes 'wang' from filter

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,9 @@ export const filter = new Filter();
 // See: https://github.com/ekzhang/setwithfriends/issues/49
 filter.removeWords("queer", "queers", "queerz", "qweers", "qweerz", "lesbian");
 
+// See: https://github.com/ekzhang/setwithfriends/issues/71
+filter.removeWords("wang");
+
 export const colors = {
   red,
   pink,

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,4 +1,10 @@
-import { conjugateCard, checkSet, checkSetUltra, findSet } from "./util";
+import {
+  conjugateCard,
+  checkSet,
+  checkSetUltra,
+  findSet,
+  filter,
+} from "./util";
 
 it("computes conjugate cards", () => {
   expect(conjugateCard("0001", "0002")).toBe("0000");
@@ -65,5 +71,12 @@ describe("findSet()", () => {
     verifyUltra(findSet(["1202", "0001", "0002", "2101"], "ultraset"));
     verifyUltra(findSet(["1202", "0000", "0001", "0002", "2101"], "ultraset"));
     expect(findSet(["1202", "0000", "0001", "0002"], "ultraset")).toBe(null);
+  });
+});
+
+describe("bad-words filter", () => {
+  it("does not trigger on 'wang'", () => {
+    expect(filter.isProfane("Rona Wang")).toBe(false);
+    expect(filter.isProfane("wang")).toBe(false);
   });
 });


### PR DESCRIPTION
This is an issue with the upstream [bad-words](https://github.com/web-mech/badwords) list (see https://github.com/MauriceButler/badwords/issues/7), so we're manually patching it to be less aggressive here.

Also added a test to make sure this doesn't regress in the future.

cc @ronaywang