### PR TITLE
Blocking chat for new accounts

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -68,6 +68,9 @@
         "lastOnline": {
           ".validate": "newData.isNumber() && newData.val() == now"
         },
+        "firstOnline": {
+          ".validate": "newData.isNumber() && newData.val() == now"
+        },
         "connections": {
           "$connectionId": {
             ".validate": "newData.isString() || !newData.exists()"
@@ -75,9 +78,6 @@
         },
         "banned": {
           ".validate": "newData.isNumber()"
-        },
-        "canChat": {
-          ".validate": "newData.isBoolean()"
         },
         "$other": {
           ".validate": false

--- a/database.rules.json
+++ b/database.rules.json
@@ -76,6 +76,9 @@
         "banned": {
           ".validate": "newData.isNumber()"
         },
+        "canChat": {
+          ".validate": "newData.isBoolean()"
+        },
         "$other": {
           ".validate": false
         }

--- a/src/App.js
+++ b/src/App.js
@@ -75,6 +75,7 @@ function App() {
         userRef.update({
           color: generateColor(),
           name: generateName(),
+          firstOnline: firebase.database.ServerValue.TIMESTAMP,
         });
       }
     }

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -18,6 +18,7 @@ import firebase from "../firebase";
 import { filter } from "../util";
 import autoscroll from "../utils/autoscroll";
 import useFirebaseQuery from "../hooks/useFirebaseQuery";
+import useFirebaseRef from "../hooks/useFirebaseRef";
 import useStorage from "../hooks/useStorage";
 import { UserContext } from "../context";
 
@@ -75,6 +76,7 @@ function Chat({
     return autoscroll(chatEl.current);
   }, []);
 
+  const [serverOffset] = useFirebaseRef("/.info/serverTimeOffset");
   const [input, setInput] = useState("");
   const [menuOpenIdx, setMenuOpenIdx] = useState(null);
   const [chatHidden, setChatHidden] = useStorage("chat-hidden", "no");
@@ -100,7 +102,7 @@ function Chat({
         );
       } else {
         const canChat = user.firstOnline
-          ? new Date().getTime() - user.firstOnline > NEW_ACCOUNT_TIME
+          ? serverOffset + Date.now() - user.firstOnline > NEW_ACCOUNT_TIME
           : true;
         if (!canChat) {
           setInput("");

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -54,6 +54,8 @@ const useStyles = makeStyles({
   },
 });
 
+const MIN_GAMES = 10;
+
 /** A chat sidebar element, opens lobby chat when the `gameId` prop is not set. */
 function Chat({
   title,
@@ -88,7 +90,7 @@ function Chat({
   );
   const messages = useFirebaseQuery(messagesQuery);
 
-  function handleSubmit(event) {
+  async function handleSubmit(event) {
     event.preventDefault();
     if (input) {
       if (filter.isProfane(input)) {
@@ -96,12 +98,32 @@ function Chat({
           "We detected that your message contains profane language. If you think this was a mistake, please let us know!"
         );
       } else {
-        firebase.database().ref(databasePath).push({
-          user: user.id,
-          message: input,
-          time: firebase.database.ServerValue.TIMESTAMP,
-        });
-        setInput("");
+        let ref = await firebase
+          .database()
+          .ref(`users/${user.id}/canChat`)
+          .once("value");
+        let canChat = ref.val();
+        if (!canChat) {
+          ref = await firebase
+            .database()
+            .ref(`/userGames/${user.id}`)
+            .once("value");
+          canChat = ref.numChildren() >= MIN_GAMES;
+          firebase.database().ref(`users/${user.id}/canChat`).set(canChat);
+        }
+        if (!canChat) {
+          setInput("");
+          alert(
+            "To prevent spam, new accounts are not allow to use chat.  Play a few games and this message should dissapear."
+          );
+        } else {
+          firebase.database().ref(databasePath).push({
+            user: user.id,
+            message: input,
+            time: firebase.database.ServerValue.TIMESTAMP,
+          });
+          setInput("");
+        }
       }
     }
   }

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -54,7 +54,8 @@ const useStyles = makeStyles({
   },
 });
 
-const MIN_GAMES = 10;
+// Time in milliseconds.
+const NEW_ACCOUNT_TIME = 5 * 60 * 1000;
 
 /** A chat sidebar element, opens lobby chat when the `gameId` prop is not set. */
 function Chat({
@@ -98,23 +99,13 @@ function Chat({
           "We detected that your message contains profane language. If you think this was a mistake, please let us know!"
         );
       } else {
-        let ref = await firebase
-          .database()
-          .ref(`users/${user.id}/canChat`)
-          .once("value");
-        let canChat = ref.val();
-        if (!canChat) {
-          ref = await firebase
-            .database()
-            .ref(`/userGames/${user.id}`)
-            .once("value");
-          canChat = ref.numChildren() >= MIN_GAMES;
-          firebase.database().ref(`users/${user.id}/canChat`).set(canChat);
-        }
+        const canChat = user.firstOnline
+          ? new Date().getTime() - user.firstOnline > NEW_ACCOUNT_TIME
+          : true;
         if (!canChat) {
           setInput("");
           alert(
-            "To prevent spam, new accounts are not allow to use chat.  Play a few games and this message should dissapear."
+            "To prevent spam, new accounts are not allowed to use chat. Play a few games and this message should disappear."
           );
         } else {
           firebase.database().ref(databasePath).push({


### PR DESCRIPTION
Stopgap measure to make it harder to spam new account when banned.  Ideally I wanted to check for 5 completed private games, but since stats are calculated on the fly, there's no quick and easy way to check this.  Currently it checks to see if a user has at least 10 games played/hosted.