### PR TITLE
Add Arc - Site monetization without ads

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,11 @@
   status = 200
 
 [[redirects]]
+  from = "/arc-sw.js"
+  to = "https://arc.io/arc-sw.js"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,10 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
     />
+
+    <% if (process.env.REACT_APP_ENV === "production") { %>
+    <script async src="https://arc.io/widget.min.js#kjP2iFJD"></script>
+    <% } %>
   </head>
 
   <body>


### PR DESCRIPTION
This is only enabled in the production deploy on Netlify (domain setwithfriends.com).