### PR TITLE
Fix "already exists" error in play again button

### DIFF
--- a/src/pages/GamePage.js
+++ b/src/pages/GamePage.js
@@ -344,8 +344,9 @@ function GamePage({ match }) {
     try {
       await createGame(newGame);
     } catch (error) {
-      if (error.code !== "already-exists") {
+      if (error.code !== "functions/already-exists") {
         alert(error.toString());
+        setWaiting(false);
         return;
       }
     }

--- a/src/pages/LobbyPage.js
+++ b/src/pages/LobbyPage.js
@@ -171,7 +171,7 @@ function LobbyPage() {
       try {
         await createGame({ gameId, access });
       } catch (error) {
-        if (error.code === "already-exists") {
+        if (error.code === "functions/already-exists") {
           // We generated an already-used game ID
           ++attempts;
           continue;


### PR DESCRIPTION
### Summary

When a multiplayer game finishes, the first person to press "play again" is able to get host of the next game and join it (so to the new game with the old game's link +1) and continue, but all other players who subsequently press "play again" get "Firebase Error: The requested `gameId` already exists."

This error arose because of a breaking change to how error codes are handled in Firebase JS SDK v9+. Previously, errors were placed in a global namespace, but now the relevant error code has been changed from "already-exists" to "functions/already-exists", causing our code to no longer detect them properly.

The fix is to look for the "functions/already-exists" error code returned by the new Firebase SDK.