### PR TITLE
Fix a undefined access error in `finishGame`

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -51,8 +51,8 @@ export const finishGame = functions.https.onCall(async (data, context) => {
   const gameSnap = await admin.database().ref(`games/${gameId}`).once("value");
   if (!gameSnap.exists()) {
     throw new functions.https.HttpsError(
-      "invalid-argument",
-      `No game with gameId ${gameId}, was found in the database.`
+      "not-found",
+      `The game with gameId ${gameId} was not found in the database.`
     );
   }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -49,6 +49,13 @@ export const finishGame = functions.https.onCall(async (data, context) => {
     .ref(`gameData/${gameId}`)
     .once("value");
   const gameSnap = await admin.database().ref(`games/${gameId}`).once("value");
+  if (!gameSnap.exists()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      `No game with gameId ${gameId}, was found in the database.`
+    );
+  }
+
   const gameMode = (gameSnap.child("mode").val() as GameMode) || "normal";
 
   const { lastSet, deck, finalTime, scores } = replayEvents(gameData, gameMode);


### PR DESCRIPTION
This change gracefully exits with an error when finishGame is called on an invalid game, rather than creating an internal server error.

This error is actually fairly common and the only non-disconnect error in our functions right now. It occurs 96K times per month. I'm not sure why this is happening, but the first step is always to provide a better error message and not to crash.