### PR TITLE
Archive games after 24h in GCS and restore automatically

### DIFF
--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -1,0 +1,59 @@
+import { type DataSnapshot, getDatabase } from "firebase-admin/database";
+import * as zlib from "node:zlib";
+
+/** Promises API wrapper around the 'zlib' Node library. */
+export const gzip = {
+  compress(
+    input: string | Buffer | ArrayBuffer | Uint8Array | DataView,
+  ): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      zlib.gzip(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+  },
+  decompress(input: Buffer): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      zlib.gunzip(input, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+  },
+};
+
+/**
+ * Iterate through a reference in the database, returning the children ordered
+ * by key in batches.
+ */
+export async function* databaseIterator(
+  path: string,
+  batchSize = 1000,
+): AsyncGenerator<[string, DataSnapshot]> {
+  let lastKey = null;
+  while (true) {
+    const snap = lastKey
+      ? await getDatabase()
+          .ref(path)
+          .orderByKey()
+          .startAfter(lastKey)
+          .limitToFirst(batchSize)
+          .get()
+      : await getDatabase()
+          .ref(path)
+          .orderByKey()
+          .limitToFirst(batchSize)
+          .get();
+    if (!snap.exists()) return;
+
+    const childKeys: string[] = [];
+    snap.forEach((child) => {
+      childKeys.push(child.key);
+      lastKey = child.key;
+    });
+    for (const key of childKeys) {
+      yield [key, snap.child(key)];
+    }
+  }
+}

--- a/scripts/src/calcStats.js
+++ b/scripts/src/calcStats.js
@@ -1,3 +1,4 @@
+// Note: This is deprecated.
 import { getDatabase } from "firebase-admin/database";
 
 const batchSize = 1000;

--- a/scripts/src/fixGames.js
+++ b/scripts/src/fixGames.js
@@ -1,3 +1,4 @@
+// Note: This is deprecated.
 import assert from "assert";
 import { getDatabase } from "firebase-admin/database";
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -26,5 +26,6 @@ const functions = firebase.functions();
 export const createGame = functions.httpsCallable("createGame");
 export const customerPortal = functions.httpsCallable("customerPortal");
 export const finishGame = functions.httpsCallable("finishGame");
+export const fetchStaleGame = functions.httpsCallable("fetchStaleGame");
 
 export default firebase;

--- a/src/pages/GamePage.js
+++ b/src/pages/GamePage.js
@@ -149,7 +149,7 @@ function GamePage() {
         }
       }
     }
-  });
+  }, [loadingGame, loadingGameData, game, gameData, fetchingStaleGame, gameId]);
 
   if (redirect) return <Navigate push to={redirect} />;
 

--- a/src/pages/GamePage.js
+++ b/src/pages/GamePage.js
@@ -20,7 +20,7 @@ import Loading from "../components/Loading";
 import SnackContent from "../components/SnackContent";
 import User from "../components/User";
 import { SettingsContext, UserContext } from "../context";
-import firebase, { createGame, finishGame } from "../firebase";
+import firebase, { createGame, fetchStaleGame, finishGame } from "../firebase";
 import useFirebaseRef from "../hooks/useFirebaseRef";
 import {
   checkSet,
@@ -81,6 +81,7 @@ function GamePage() {
   const [selected, setSelected] = useState([]);
   const [snack, setSnack] = useState({ open: false });
   const [numHints, setNumHints] = useState(0);
+  const [fetchingStaleGame, setFetchingStaleGame] = useState("not-stale");
 
   const [game, loadingGame] = useFirebaseRef(`games/${gameId}`);
   const [gameData, loadingGameData] = useFirebaseRef(`gameData/${gameId}`);
@@ -128,9 +129,35 @@ function GamePage() {
     }
   });
 
+  // Try to fetch the game from cloud storage, if archived due to being stale.
+  useEffect(() => {
+    if (!loadingGame && !loadingGameData) {
+      if (game && gameData) {
+        if (fetchingStaleGame !== "not-stale") {
+          setFetchingStaleGame("not-stale");
+        }
+      } else {
+        if (fetchingStaleGame === "not-stale") {
+          setFetchingStaleGame("fetching");
+          (async () => {
+            // On success, the database should automatically update with game state.
+            const { restored } = await fetchStaleGame({ gameId });
+            if (!restored) {
+              setFetchingStaleGame("failed");
+            }
+          })();
+        }
+      }
+    }
+  });
+
   if (redirect) return <Navigate push to={redirect} />;
 
-  if (loadingGame || loadingGameData) {
+  if (
+    loadingGame ||
+    loadingGameData ||
+    ((!game || !gameData) && fetchingStaleGame !== "failed")
+  ) {
     return <LoadingPage />;
   }
 


### PR DESCRIPTION
This reduces storage costs from $5/GB/month to about $0.02/GB/month (250x) with almost no downside. It also uses gzip which provides another 3x compression ratio, reducing cost again. So what was costing $150/month previously to store 10 million games, and required us to drop the database, now would only cost $0.20/month.

Need to test thoroughly in setwihfriends-dev before I can promote to production. Don't want to lose a bunch of data!