### PR TITLE
Add legal link to about page, replace with GitHub link

### DIFF
--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -76,19 +76,13 @@ function AboutPage() {
       </Paper>
       <Paper style={{ padding: "1rem", maxWidth: 720, margin: "12px auto" }}>
         <Typography variant="body2">
-          Sounds used from{" "}
+          By using this site, you agree to our{" "}
+          <InternalLink to="/legal">terms of service</InternalLink>. Sounds from{" "}
           <Link
             href="https://notificationsounds.com/terms-of-use"
             underline="hover"
           >
             notificationsounds.com
-          </Link>
-          &nbsp;are provided under a{" "}
-          <Link
-            href="https://creativecommons.org/licenses/by/4.0/legalcode"
-            underline="hover"
-          >
-            Creative Commons Attribution license
           </Link>
           .
         </Typography>

--- a/src/pages/LobbyPage.js
+++ b/src/pages/LobbyPage.js
@@ -308,7 +308,15 @@ function LobbyPage() {
         <InternalLink to="/about">About</InternalLink> •{" "}
         <InternalLink to="/conduct">Conduct</InternalLink> •{" "}
         <InternalLink to="/donate">Donate</InternalLink> •{" "}
-        <InternalLink to="/legal">Legal</InternalLink> •{" "}
+        <Link
+          target="_blank"
+          rel="noopener"
+          href="https://github.com/ekzhang/setwithfriends"
+          underline="hover"
+        >
+          GitHub
+        </Link>{" "}
+        •{" "}
         <Link
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
Closes #143.