### PR TITLE
Fix display of custom card colors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,13 +88,19 @@ function App() {
     if (parsedCustoms.light) {
       setCustomLightTheme({
         ...lightTheme,
-        setCard: { ...lightTheme.custom.setCard, ...parsedCustoms.light },
+        custom: {
+          ...lightTheme.custom,
+          setCard: { ...lightTheme.custom.setCard, ...parsedCustoms.light },
+        },
       });
     }
     if (parsedCustoms.dark) {
       setCustomDarkTheme({
         ...darkTheme,
-        setCard: { ...darkTheme.custom.setCard, ...parsedCustoms.dark },
+        custom: {
+          ...darkTheme.custom,
+          setCard: { ...darkTheme.custom.setCard, ...parsedCustoms.dark },
+        },
       });
     }
   }, [customColors]);


### PR DESCRIPTION
This was not working after a recent change that upgraded Material UI.