### PR TITLE
Ignore Ctrl or Alt in card shortcut key handlers

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -161,24 +161,28 @@ function Game({
     ? keyboardLayoutDesc.horizontalLayout
     : keyboardLayoutDesc.verticalLayout;
   useKeydown((event) => {
-    const { key } = event;
-    if (key === "Escape") {
-      event.preventDefault();
-      onClear();
-    } else if (key.length === 1 && shortcuts.includes(key.toLowerCase())) {
-      event.preventDefault();
-      const index = shortcuts.indexOf(key.toLowerCase());
-      if (index < board.length) {
-        onClick(board[index]);
+    const { key, ctrlKey, metaKey } = event;
+    if (!ctrlKey && !metaKey) {
+      if (key === "Escape") {
+        event.preventDefault();
+        onClear();
+      } else if (key.length === 1 && shortcuts.includes(key.toLowerCase())) {
+        event.preventDefault();
+        const index = shortcuts.indexOf(key.toLowerCase());
+        if (index < board.length) {
+          onClick(board[index]);
+        }
+      } else if (
+        key.toLowerCase() === keyboardLayoutDesc.orientationChangeKey
+      ) {
+        event.preventDefault();
+        if (volume === "on") playLayout();
+        setCardOrientation(isHorizontal ? "vertical" : "horizontal");
+      } else if (key.toLowerCase() === keyboardLayoutDesc.layoutChangeKey) {
+        event.preventDefault();
+        if (volume === "on") playLayout();
+        setLayoutOrientation(isLandscape ? "portrait" : "landscape");
       }
-    } else if (key.toLowerCase() === keyboardLayoutDesc.orientationChangeKey) {
-      event.preventDefault();
-      if (volume === "on") playLayout();
-      setCardOrientation(isHorizontal ? "vertical" : "horizontal");
-    } else if (key.toLowerCase() === keyboardLayoutDesc.layoutChangeKey) {
-      event.preventDefault();
-      if (volume === "on") playLayout();
-      setLayoutOrientation(isLandscape ? "portrait" : "landscape");
     }
   });
 


### PR DESCRIPTION
This means that Ctrl+R / Cmd+R will now work as a way to refresh the page when you're in game.